### PR TITLE
Fix invalid JSON in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ MCP (Model Control Protocol) lets you run Task Master directly from your editor.
         "OPENROUTER_API_KEY": "YOUR_OPENROUTER_KEY_HERE",
         "XAI_API_KEY": "YOUR_XAI_KEY_HERE",
         "AZURE_OPENAI_API_KEY": "YOUR_AZURE_KEY_HERE",
-        "OLLAMA_API_KEY": "YOUR_OLLAMA_API_KEY_HERE",
-      },
-    },
-  },
+        "OLLAMA_API_KEY": "YOUR_OLLAMA_API_KEY_HERE"
+      }
+    }
+  }
 }
 ```
 
@@ -83,11 +83,11 @@ MCP (Model Control Protocol) lets you run Task Master directly from your editor.
         "MISTRAL_API_KEY": "YOUR_MISTRAL_KEY_HERE",
         "OPENROUTER_API_KEY": "YOUR_OPENROUTER_KEY_HERE",
         "XAI_API_KEY": "YOUR_XAI_KEY_HERE",
-        "AZURE_OPENAI_API_KEY": "YOUR_AZURE_KEY_HERE",
+        "AZURE_OPENAI_API_KEY": "YOUR_AZURE_KEY_HERE"
       },
-      "type": "stdio",
-    },
-  },
+      "type": "stdio"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- fix trailing commas in JSON configuration snippets in `README.md`

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6843159b6448832b96d06d84a397f4b9